### PR TITLE
Set up valid_move? for Knight subclass

### DIFF
--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -1,2 +1,23 @@
 class Knight < Piece
+	def valid_move?(x, y)
+		# check validity based on board position - moves off board are invalid. This logic is built into is_obstructed but we aren't calling that method in this subclass
+		if x > 7 || x < 0 || y > 7 || y < 0
+			return false
+		# l-shapes upward
+		elsif y == position_y + 2 && (x == position_x + 1 || x == position_x - 1)
+			return true
+		# l-shapes to the right
+		elsif x == position_x + 2 && (y == position_y + 1 || y == position_y - 1)
+			return true
+		# l-shapes downward
+		elsif y == position_y - 2 && (x == position_x - 1 || x == position_x + 1)
+			return true
+		# l-shapes to the left
+		elsif x == position_y - 2 && (x == position_x + 1 || x == position_x - 1)
+			return true
+		# all other cases
+		else
+			return false
+		end
+	end
 end


### PR DESCRIPTION
Set up `valid_move?` for Knight subclass. Did not use `is_obstructed?` because Knights can jump over pieces in their paths, and their move pattern is not linear.