### PR TITLE
Add valid move for pawn

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -6,38 +6,38 @@ class Game < ApplicationRecord
   # one potential limitation of this method is that pieces will only be populated if the game has a valid user_id AND an opponent
   def populate_board!
     # QUEENS - the user who created the game will be black, the opponent will be white
-    Piece.create(game_id: id, user_id: user_id, position_x: 3, position_y: 7, name: "black queen")
-    Piece.create(game_id: id, user_id: opponent, position_x: 3, position_y: 0, name: "white queen")
+    Piece.create(game_id: id, user_id: user_id, position_x: 3, position_y: 7, color: "black", name: "black queen")
+    Piece.create(game_id: id, user_id: opponent, position_x: 3, position_y: 0, color: "white", name: "white queen")
     # KINGS
-    Piece.create(game_id: id, user_id: user_id, position_x: 4, position_y: 7, name: "black king")
-    Piece.create(game_id: id, user_id: opponent, position_x: 4, position_y: 0, name: "white king")
+    Piece.create(game_id: id, user_id: user_id, position_x: 4, position_y: 7, color: "black", name: "black king")
+    Piece.create(game_id: id, user_id: opponent, position_x: 4, position_y: 0, color: "white", name: "white king")
     # BISHOPS
     # black bishops
-    Piece.create(game_id: id, user_id: user_id, position_x: 2, position_y: 7, name: "black bishop 1")
-    Piece.create(game_id: id, user_id: user_id, position_x: 5, position_y: 7, name: "black bishop 2")
+    Piece.create(game_id: id, user_id: user_id, position_x: 2, position_y: 7, color: "black", name: "black bishop 1")
+    Piece.create(game_id: id, user_id: user_id, position_x: 5, position_y: 7, color: "black", name: "black bishop 2")
     # white bishops
-    Piece.create(game_id: id, user_id: opponent, position_x: 2, position_y: 0, name: "white bishop 1")
-    Piece.create(game_id: id, user_id: opponent, position_x: 5, position_y: 0, name: "white bishop 2")
+    Piece.create(game_id: id, user_id: opponent, position_x: 2, position_y: 0, color: "white", name: "white bishop 1")
+    Piece.create(game_id: id, user_id: opponent, position_x: 5, position_y: 0, color: "white", name: "white bishop 2")
     # KNIGHTS
     # black knights
-    Piece.create(game_id: id, user_id: user_id, position_x: 1, position_y: 7, name: "black knight 1")
-    Piece.create(game_id: id, user_id: user_id, position_x: 6, position_y: 7, name: "black knight 2")
+    Piece.create(game_id: id, user_id: user_id, position_x: 1, position_y: 7, color: "black", name: "black knight 1")
+    Piece.create(game_id: id, user_id: user_id, position_x: 6, position_y: 7, color: "black", name: "black knight 2")
     # white knights
-    Piece.create(game_id: id, user_id: opponent, position_x: 1, position_y: 0, name: "white knight 1")
-    Piece.create(game_id: id, user_id: opponent, position_x: 6, position_y: 0, name: "white knight 2")
+    Piece.create(game_id: id, user_id: opponent, position_x: 1, position_y: 0, color: "white", name: "white knight 1")
+    Piece.create(game_id: id, user_id: opponent, position_x: 6, position_y: 0, color: "white", name: "white knight 2")
     # rooks
     # black rooks
-    Piece.create(game_id: id, user_id: user_id, position_x: 0, position_y: 7, name: "black rook 1")
-    Piece.create(game_id: id, user_id: user_id, position_x: 7, position_y: 7, name: "black rook 2")
+    Piece.create(game_id: id, user_id: user_id, position_x: 0, position_y: 7, color: "black", name: "black rook 1")
+    Piece.create(game_id: id, user_id: user_id, position_x: 7, position_y: 7, color: "black", name: "black rook 2")
     # white rooks
-    Piece.create(game_id: id, user_id: opponent, position_x: 0, position_y: 0, name: "white rook 1")
-    Piece.create(game_id: id, user_id: opponent, position_x: 7, position_y: 0, name: "white rook 2")
+    Piece.create(game_id: id, user_id: opponent, position_x: 0, position_y: 0, color: "white", name: "white rook 1")
+    Piece.create(game_id: id, user_id: opponent, position_x: 7, position_y: 0, color: "white", name: "white rook 2")
     # PAWNS
     # populate black pawns
     black_pawn_x = 0
     black_pawn_number = 1
     8.times do
-      Piece.create(game_id: id, user_id: user_id, position_x: black_pawn_x, position_y: 6, name: "black pawn #{black_pawn_number}")
+      Piece.create(game_id: id, user_id: user_id, position_x: black_pawn_x, position_y: 6, color: "black", name: "black pawn #{black_pawn_number}")
       black_pawn_x += 1
       black_pawn_number += 1
     end
@@ -45,7 +45,7 @@ class Game < ApplicationRecord
     white_pawn_x = 0
     white_pawn_number = 1
     8.times do
-      Piece.create(game_id: id, user_id: opponent, position_x: white_pawn_x, position_y: 1, name: "white pawn #{white_pawn_number}")
+      Piece.create(game_id: id, user_id: opponent, position_x: white_pawn_x, position_y: 1, color: "white", name: "white pawn #{white_pawn_number}")
       white_pawn_x += 1
       white_pawn_number += 1
     end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -6,38 +6,38 @@ class Game < ApplicationRecord
   # one potential limitation of this method is that pieces will only be populated if the game has a valid user_id AND an opponent
   def populate_board!
     # QUEENS - the user who created the game will be black, the opponent will be white
-    Piece.create(game_id: id, user_id: user_id, position_x: 3, position_y: 7, color: "black", name: "black queen")
-    Piece.create(game_id: id, user_id: opponent, position_x: 3, position_y: 0, color: "white", name: "white queen")
+    Queen.create(game_id: id, user_id: user_id, position_x: 3, position_y: 7, color: "black", name: "black queen")
+    Queen.create(game_id: id, user_id: opponent, position_x: 3, position_y: 0, color: "white", name: "white queen")
     # KINGS
-    Piece.create(game_id: id, user_id: user_id, position_x: 4, position_y: 7, color: "black", name: "black king")
-    Piece.create(game_id: id, user_id: opponent, position_x: 4, position_y: 0, color: "white", name: "white king")
+    King.create(game_id: id, user_id: user_id, position_x: 4, position_y: 7, color: "black", name: "black king")
+    King.create(game_id: id, user_id: opponent, position_x: 4, position_y: 0, color: "white", name: "white king")
     # BISHOPS
     # black bishops
-    Piece.create(game_id: id, user_id: user_id, position_x: 2, position_y: 7, color: "black", name: "black bishop 1")
-    Piece.create(game_id: id, user_id: user_id, position_x: 5, position_y: 7, color: "black", name: "black bishop 2")
+    Bishop.create(game_id: id, user_id: user_id, position_x: 2, position_y: 7, color: "black", name: "black bishop 1")
+    Bishop.create(game_id: id, user_id: user_id, position_x: 5, position_y: 7, color: "black", name: "black bishop 2")
     # white bishops
-    Piece.create(game_id: id, user_id: opponent, position_x: 2, position_y: 0, color: "white", name: "white bishop 1")
-    Piece.create(game_id: id, user_id: opponent, position_x: 5, position_y: 0, color: "white", name: "white bishop 2")
+    Bishop.create(game_id: id, user_id: opponent, position_x: 2, position_y: 0, color: "white", name: "white bishop 1")
+    Bishop.create(game_id: id, user_id: opponent, position_x: 5, position_y: 0, color: "white", name: "white bishop 2")
     # KNIGHTS
     # black knights
-    Piece.create(game_id: id, user_id: user_id, position_x: 1, position_y: 7, color: "black", name: "black knight 1")
-    Piece.create(game_id: id, user_id: user_id, position_x: 6, position_y: 7, color: "black", name: "black knight 2")
+    Knight.create(game_id: id, user_id: user_id, position_x: 1, position_y: 7, color: "black", name: "black knight 1")
+    Knight.create(game_id: id, user_id: user_id, position_x: 6, position_y: 7, color: "black", name: "black knight 2")
     # white knights
-    Piece.create(game_id: id, user_id: opponent, position_x: 1, position_y: 0, color: "white", name: "white knight 1")
-    Piece.create(game_id: id, user_id: opponent, position_x: 6, position_y: 0, color: "white", name: "white knight 2")
+    Knight.create(game_id: id, user_id: opponent, position_x: 1, position_y: 0, color: "white", name: "white knight 1")
+    Knight.create(game_id: id, user_id: opponent, position_x: 6, position_y: 0, color: "white", name: "white knight 2")
     # rooks
     # black rooks
-    Piece.create(game_id: id, user_id: user_id, position_x: 0, position_y: 7, color: "black", name: "black rook 1")
-    Piece.create(game_id: id, user_id: user_id, position_x: 7, position_y: 7, color: "black", name: "black rook 2")
+    Rook.create(game_id: id, user_id: user_id, position_x: 0, position_y: 7, color: "black", name: "black rook 1")
+    Rook.create(game_id: id, user_id: user_id, position_x: 7, position_y: 7, color: "black", name: "black rook 2")
     # white rooks
-    Piece.create(game_id: id, user_id: opponent, position_x: 0, position_y: 0, color: "white", name: "white rook 1")
-    Piece.create(game_id: id, user_id: opponent, position_x: 7, position_y: 0, color: "white", name: "white rook 2")
+    Rook.create(game_id: id, user_id: opponent, position_x: 0, position_y: 0, color: "white", name: "white rook 1")
+    Rook.create(game_id: id, user_id: opponent, position_x: 7, position_y: 0, color: "white", name: "white rook 2")
     # PAWNS
     # populate black pawns
     black_pawn_x = 0
     black_pawn_number = 1
     8.times do
-      Piece.create(game_id: id, user_id: user_id, position_x: black_pawn_x, position_y: 6, color: "black", name: "black pawn #{black_pawn_number}")
+      Pawn.create(game_id: id, user_id: user_id, position_x: black_pawn_x, position_y: 6, color: "black", name: "black pawn #{black_pawn_number}")
       black_pawn_x += 1
       black_pawn_number += 1
     end
@@ -45,7 +45,7 @@ class Game < ApplicationRecord
     white_pawn_x = 0
     white_pawn_number = 1
     8.times do
-      Piece.create(game_id: id, user_id: opponent, position_x: white_pawn_x, position_y: 1, color: "white", name: "white pawn #{white_pawn_number}")
+      Pawn.create(game_id: id, user_id: opponent, position_x: white_pawn_x, position_y: 1, color: "white", name: "white pawn #{white_pawn_number}")
       white_pawn_x += 1
       white_pawn_number += 1
     end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -7,10 +7,11 @@ class King < Piece
     elsif x == position_x && (y == position_y + 1 || y == position_y - 1)
       return true
     # check if it's a valid diagonal move
-    elsif (x == position_x + 1 && y == position_y +1) || (x == position_x - 1 && y == position_y + 1) || (x == position_x - 1 && y == position_y - 1) || (x == position_x + 1 && y == position_y - 1)
+    elsif (x == position_x + 1 && y == position_y + 1) || (x == position_x - 1 && y == position_y + 1) || (x == position_x - 1 && y == position_y - 1) || (x == position_x + 1 && y == position_y - 1)
       return true
     # if none of the above, false
     else
       return false
     end
+  end
 end

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -1,2 +1,23 @@
 class Knight < Piece
+	def valid_move?(x, y)
+		# check validity based on board position - moves off board are invalid. This logic is built into is_obstructed but we aren't calling that method in this subclass
+		if x > 7 || x < 0 || y > 7 || y < 0
+			return false
+		# l-shapes upward
+		elsif y == position_y + 2 && (x == position_x + 1 || x == position_x - 1)
+			return true
+		# l-shapes to the right
+		elsif x == position_x + 2 && (y == position_y + 1 || y == position_y - 1)
+			return true
+		# l-shapes downward
+		elsif y == position_y - 2 && (x == position_x - 1 || x == position_x + 1)
+			return true
+		# l-shapes to the left
+		elsif x == position_y - 2 && (x == position_x + 1 || x == position_x - 1)
+			return true
+		# all other cases
+		else
+			return false
+		end
+	end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,2 +1,60 @@
 class Pawn < Piece
+	def valid_move?(x, y)
+		# if the piece belongs to the white player, moving forward means position_y + 1
+		if color == "white"
+			# check for invalid moves
+			if x > 7 || x < 0 || y > 7 || y < 0
+				return false
+			# if it's a white pawn's first move, can move two spaces forward to position_y + 2
+			elsif y == position_y + 2 && x == position_x && move_count == 0
+				if self.is_obstructed?(x, y)
+					return false
+				else
+					return true
+				end
+			# if it's not the white pawn's first move, it can move forward to position_y + 1
+			elsif y == position_y + 1 && x == position_x && move_count > 0
+				if self.is_obstructed?(x, y)
+					return false
+				else
+					return true
+				end
+			# regardless of move_count, the pawn can move forward to position_y + 1 and one space to the left or right, then capture the piece_in_space, if any
+			elsif y == position_y + 1 && (x == position_x - 1 || x == position_x + 1)
+				if self.is_obstructed?(x, y)
+					move_to(x, y)
+				else
+					return false
+				end
+			end
+		end
+
+		if color == "black"
+			# check for invalid moves
+			if x > 7 || x < 0 || y > 7 || y < 0
+				return false
+			# if it's a black pawn's first move, can move two spaces forward to position_y - 2
+			elsif y == position_y - 2 && x == position_x && move_count == 0
+				if self.is_obstructed?(x, y)
+					return false
+				else
+					return true
+				end
+			# if it's not the black pawn's first move, it can move forward to position_y - 1
+			elsif y == position_y + 1 && x == position_x && move_count > 0
+				if self.is_obstructed?(x, y)
+					return false
+				else
+					return true
+				end
+			# regardless of move_count, the pawn can move forward to position_y - 1 and one space to the left or right, then capture the piece_in_space, if any
+			elsif y == position_y - 1 && (x == position_x - 1 || x == position_x + 1)
+				if self.is_obstructed?(x, y)
+					move_to(x, y)
+				else
+					return false
+				end
+			end
+		end
+	end
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,59 +1,57 @@
 class Pawn < Piece
 	def valid_move?(x, y)
-		# if the piece belongs to the white player, moving forward means position_y + 1
+		# if the piece belongs to the white player, moving forward means adding to position_y
 		if color == "white"
-			# check for invalid moves
-			if x > 7 || x < 0 || y > 7 || y < 0
-				return false
-			# if it's a white pawn's first move, can move two spaces forward to position_y + 2
-			elsif y == position_y + 2 && x == position_x && move_count == 0
+			# if it's a white pawn's first move, it is valid for an unbstructed white pawn to move two spaces forward to position_y + 2
+			if y == position_y + 2 && x == position_x && move_count == 0
 				if self.is_obstructed?(x, y)
 					return false
 				else
 					return true
 				end
-			# if it's not the white pawn's first move, it can move forward to position_y + 1
-			elsif y == position_y + 1 && x == position_x && move_count > 0
+			# regardless of move_count, it is valid for an unobstructed black pawn to move forward to position_y + 1
+			elsif y == position_y + 1 && x == position_x && move_count >= 0
 				if self.is_obstructed?(x, y)
 					return false
 				else
 					return true
 				end
-			# regardless of move_count, the pawn can move forward to position_y + 1 and one space to the left or right, then capture the piece_in_space, if any
+			# regardless of move_count, it is valid for a white pawn to move forward to position_y + 1 and one space to the left or right, then capture the piece_in_space (self.is_obstructed?(x, y) must == true)
 			elsif y == position_y + 1 && (x == position_x - 1 || x == position_x + 1)
 				if self.is_obstructed?(x, y)
 					move_to(x, y)
 				else
 					return false
 				end
+			else
+				return false
 			end
 		end
-
+		# if the piece belongs to the black player, moving forward means subtracting from position_y
 		if color == "black"
-			# check for invalid moves
-			if x > 7 || x < 0 || y > 7 || y < 0
-				return false
-			# if it's a black pawn's first move, can move two spaces forward to position_y - 2
-			elsif y == position_y - 2 && x == position_x && move_count == 0
+			# if it's a black pawn's first move, it is valid for an unbstructed black pawn to move two spaces forward to position_y - 2
+			if y == position_y - 2 && x == position_x && move_count == 0
 				if self.is_obstructed?(x, y)
 					return false
 				else
 					return true
 				end
-			# if it's not the black pawn's first move, it can move forward to position_y - 1
-			elsif y == position_y + 1 && x == position_x && move_count > 0
+			# regardless of move_count, it is valid for an unobstructed black pawn to move forward to position_y - 1
+			elsif y == position_y - 1 && x == position_x && move_count >= 0
 				if self.is_obstructed?(x, y)
 					return false
 				else
 					return true
 				end
-			# regardless of move_count, the pawn can move forward to position_y - 1 and one space to the left or right, then capture the piece_in_space, if any
+			# regardless of move_count, it is valid for a black pawn can move forward to position_y - 1 and one space to the left or right to capture the piece_in_space (self.is_obstructed?(x, y) must == true)
 			elsif y == position_y - 1 && (x == position_x - 1 || x == position_x + 1)
 				if self.is_obstructed?(x, y)
 					move_to(x, y)
 				else
 					return false
 				end
+			else
+				return false
 			end
 		end
 	end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -150,5 +150,9 @@ class Piece < ApplicationRecord
     end
     # Move the piece to the designated coordinates
     self.update_attributes(position_x: x, position_y: y)
+
+    # update the move_count
+    new_move_count = self.move_count + 1
+    self.update_attributes(move_count: new_move_count)
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -138,12 +138,12 @@ class Piece < ApplicationRecord
       other_piece = Piece.find_by(position_x: x, position_y: y)
 
       # If piece belongs to opponent, remove it from the board
-      if other_piece.user_id == game.opponent
+      if other_piece.user_id != current_user
         remove_piece(other_piece)
       end
 
       # If piece belongs to player, the move should fail
-      if other_piece.user_id == game.user_id
+      if other_piece.user_id == current_user
         return 'Move failed'
       end
 

--- a/db/migrate/20180908195813_add_move_count_to_pieces.rb
+++ b/db/migrate/20180908195813_add_move_count_to_pieces.rb
@@ -1,0 +1,5 @@
+class AddMoveCountToPieces < ActiveRecord::Migration[5.0]
+  def change
+  	add_column :pieces, :move_count, :integer, :default => 0
+  end
+end

--- a/db/migrate/20180911041340_add_color_to_pieces.rb
+++ b/db/migrate/20180911041340_add_color_to_pieces.rb
@@ -1,0 +1,5 @@
+class AddColorToPieces < ActiveRecord::Migration[5.0]
+  def change
+  	add_column :pieces, :color, :string
+  end
+end

--- a/db/migrate/20180911044311_add_type_to_pieces.rb
+++ b/db/migrate/20180911044311_add_type_to_pieces.rb
@@ -1,0 +1,5 @@
+class AddTypeToPieces < ActiveRecord::Migration[5.0]
+  def change
+    add_column :pieces, :type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180904024930) do
+ActiveRecord::Schema.define(version: 20180911041340) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,9 +32,11 @@ ActiveRecord::Schema.define(version: 20180904024930) do
     t.integer  "position_x"
     t.integer  "position_y"
     t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
     t.string   "status"
+    t.integer  "move_count", default: 0
+    t.string   "color"
     t.index ["game_id"], name: "index_pieces_on_game_id", using: :btree
     t.index ["user_id"], name: "index_pieces_on_user_id", using: :btree
   end

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe GamesController, type: :controller do
       game = Game.last
       expect(game.opponent).to eq(user2.id)
       expect(game.pieces.count).to eq(32)
+      expect(game.pieces.last.color).to eq("white")
     end
   end
 end


### PR DESCRIPTION
- Updated Piece database table to include: `color`, `move_count`, and `type`
- Updated Game `populate_board!` method to create instances of specific Piece subclasses, so that pieces can access their subclass methods
- Cleaned up King `valid_move?` method to eliminate errors when creating instances of the King subclass (this change should be overwritten by the open PR for updated king `valid_move?` logic as this is an outdated version of the King model)
- Updated `move_to` to increment a piece's `move_count` if the piece is moved there
- Updated `move_to` logic to base obstruction logic on `current_user` id